### PR TITLE
feat: Add container naming and list functionality with fixes

### DIFF
--- a/src/code-sandbox-mcp/tools/copy-file-from-container.go
+++ b/src/code-sandbox-mcp/tools/copy-file-from-container.go
@@ -16,9 +16,9 @@ import (
 // CopyFileFromContainer copies a single file from a container's filesystem to the local filesystem
 func CopyFileFromContainer(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Extract parameters
-	containerID, ok := request.Params.Arguments["container_id"].(string)
-	if !ok || containerID == "" {
-		return mcp.NewToolResultText("container_id is required"), nil
+	containerIDOrName, ok := request.Params.Arguments["container_id_or_name"].(string)
+	if !ok || containerIDOrName == "" {
+		return mcp.NewToolResultText("container_id_or_name is required"), nil
 	}
 
 	containerSrcPath, ok := request.Params.Arguments["container_src_path"].(string)
@@ -45,15 +45,15 @@ func CopyFileFromContainer(ctx context.Context, request mcp.CallToolRequest) (*m
 	}
 
 	// Copy the file from the container
-	if err := copyFileFromContainer(ctx, containerID, containerSrcPath, localDestPath); err != nil {
+	if err := copySingleFileFromContainer(ctx, containerIDOrName, containerSrcPath, localDestPath); err != nil {
 		return mcp.NewToolResultText(fmt.Sprintf("Error copying file from container: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Successfully copied %s from container %s to %s", containerSrcPath, containerID, localDestPath)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Successfully copied %s from container %s to %s", containerSrcPath, containerIDOrName, localDestPath)), nil
 }
 
-// copyFileFromContainer copies a single file from the container to the local filesystem
-func copyFileFromContainer(ctx context.Context, containerID string, srcPath string, destPath string) error {
+// copySingleFileFromContainer copies a single file from the container to the local filesystem
+func copySingleFileFromContainer(ctx context.Context, containerIDOrName string, srcPath string, destPath string) error {
 	cli, err := client.NewClientWithOpts(
 		client.FromEnv,
 		client.WithAPIVersionNegotiation(),
@@ -64,7 +64,7 @@ func copyFileFromContainer(ctx context.Context, containerID string, srcPath stri
 	defer cli.Close()
 
 	// Create reader for the file from container
-	reader, stat, err := cli.CopyFromContainer(ctx, containerID, srcPath)
+	reader, stat, err := cli.CopyFromContainer(ctx, containerIDOrName, srcPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy from container: %w", err)
 	}

--- a/src/code-sandbox-mcp/tools/list.go
+++ b/src/code-sandbox-mcp/tools/list.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// SandboxInfo holds information about a running sandbox container.
+type SandboxInfo struct {
+	ContainerID string `json:"container_id"`
+	Name        string `json:"name"`
+	Image       string `json:"image"`
+	Status      string `json:"status"`
+}
+
+// ListSandboxes lists all running sandbox containers.
+func ListSandboxes(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, mcp.NewToolResultError("DOCKER_CLIENT_ERROR", fmt.Sprintf("failed to create Docker client: %v", err))
+	}
+	defer cli.Close()
+
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
+	if err != nil {
+		return nil, mcp.NewToolResultError("CONTAINER_LIST_ERROR", fmt.Sprintf("failed to list containers: %v", err))
+	}
+
+	var sandboxes []SandboxInfo
+	for _, container := range containers {
+		sandboxes = append(sandboxes, SandboxInfo{
+			ContainerID: container.ID[:12],
+			Name:        strings.TrimPrefix(container.Names[0], "/"),
+			Image:       container.Image,
+			Status:      container.Status,
+		})
+	}
+
+	return mcp.NewToolResultResource(sandboxes), nil
+}

--- a/src/code-sandbox-mcp/tools/list.go
+++ b/src/code-sandbox-mcp/tools/list.go
@@ -2,10 +2,11 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -22,24 +23,34 @@ type SandboxInfo struct {
 func ListSandboxes(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		return nil, mcp.NewToolResultError("DOCKER_CLIENT_ERROR", fmt.Sprintf("failed to create Docker client: %v", err))
+		return nil, fmt.Errorf("DOCKER_CLIENT_ERROR: failed to create Docker client: %v", err)
 	}
 	defer cli.Close()
 
-	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
+	containers, err := cli.ContainerList(ctx, container.ListOptions{})
 	if err != nil {
-		return nil, mcp.NewToolResultError("CONTAINER_LIST_ERROR", fmt.Sprintf("failed to list containers: %v", err))
+		return nil, fmt.Errorf("CONTAINER_LIST_ERROR: failed to list containers: %v", err)
 	}
 
 	var sandboxes []SandboxInfo
-	for _, container := range containers {
+	for _, c := range containers {
+		var name string
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
+
 		sandboxes = append(sandboxes, SandboxInfo{
-			ContainerID: container.ID[:12],
-			Name:        strings.TrimPrefix(container.Names[0], "/"),
-			Image:       container.Image,
-			Status:      container.Status,
+			ContainerID: c.ID[:12],
+			Name:        name,
+			Image:       c.Image,
+			Status:      c.Status,
 		})
 	}
 
-	return mcp.NewToolResultResource(sandboxes), nil
+	jsonData, err := json.Marshal(sandboxes)
+	if err != nil {
+		return nil, fmt.Errorf("JSON_SERIALIZE_ERROR: failed to serialize sandbox list: %v", err)
+	}
+
+	return mcp.NewToolResultText(string(jsonData)), nil
 }

--- a/src/code-sandbox-mcp/tools/stop-container.go
+++ b/src/code-sandbox-mcp/tools/stop-container.go
@@ -9,24 +9,24 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// StopContainer stops and removes a container by its ID
+// StopContainer stops and removes a container by its ID or name
 func StopContainer(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	// Get the container ID from the request
-	containerId, ok := request.Params.Arguments["container_id"].(string)
-	if !ok || containerId == "" {
-		return mcp.NewToolResultText("Error: container_id is required"), nil
+	// Get the container ID or name from the request
+	containerIdOrName, ok := request.Params.Arguments["container_id_or_name"].(string)
+	if !ok || containerIdOrName == "" {
+		return mcp.NewToolResultText("Error: container_id_or_name is required"), nil
 	}
 
 	// Stop and remove the container
-	if err := stopAndRemoveContainer(ctx, containerId); err != nil {
+	if err := stopAndRemoveContainer(ctx, containerIdOrName); err != nil {
 		return mcp.NewToolResultText(fmt.Sprintf("Error: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Successfully stopped and removed container: %s", containerId)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Successfully stopped and removed container: %s", containerIdOrName)), nil
 }
 
 // stopAndRemoveContainer stops and removes a Docker container
-func stopAndRemoveContainer(ctx context.Context, containerId string) error {
+func stopAndRemoveContainer(ctx context.Context, containerIdOrName string) error {
 	cli, err := client.NewClientWithOpts(
 		client.FromEnv,
 		client.WithAPIVersionNegotiation(),
@@ -38,12 +38,12 @@ func stopAndRemoveContainer(ctx context.Context, containerId string) error {
 
 	// Stop the container with a timeout
 	timeout := 10 // seconds
-	if err := cli.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &timeout}); err != nil {
+	if err := cli.ContainerStop(ctx, containerIdOrName, container.StopOptions{Timeout: &timeout}); err != nil {
 		return fmt.Errorf("failed to stop container: %w", err)
 	}
 
 	// Remove the container
-	if err := cli.ContainerRemove(ctx, containerId, container.RemoveOptions{
+	if err := cli.ContainerRemove(ctx, containerIdOrName, container.RemoveOptions{
 		RemoveVolumes: true,
 		Force:         true,
 	}); err != nil {

--- a/src/code-sandbox-mcp/tools/tools_test.go
+++ b/src/code-sandbox-mcp/tools/tools_test.go
@@ -1,0 +1,97 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockCallToolRequest(toolName string, params map[string]interface{}) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments,omitempty"`
+			Meta      *struct {
+				ProgressToken mcp.ProgressToken "json:\"progressToken,omitempty\""
+			} "json:\"_meta,omitempty\""
+		}{
+			Name:      toolName,
+			Arguments: params,
+		},
+	}
+}
+
+func TestSandboxLifecycle(t *testing.T) {
+	ctx := context.Background()
+	containerName := "mcp-test-container-lifecycle"
+
+	// 1. Initialize
+	initRequest := newMockCallToolRequest("sandbox_initialize", map[string]interface{}{
+		"image": "alpine:latest",
+		"name":  containerName,
+	})
+	initResult, err := InitializeEnvironment(ctx, initRequest)
+	require.NoError(t, err)
+	require.NotNil(t, initResult)
+	require.Len(t, initResult.Content, 1)
+
+	textContent, ok := initResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+
+	parts := strings.Split(textContent.Text, ": ")
+	require.Len(t, parts, 2, "Initialize result should be in 'container_id: xxx' format")
+	containerID := parts[1]
+	require.NotEmpty(t, containerID)
+
+	// Defer Stop to ensure cleanup
+	defer func() {
+		stopRequest := newMockCallToolRequest("sandbox_stop", map[string]interface{}{
+			"container_id_or_name": containerName,
+		})
+		_, err := StopContainer(ctx, stopRequest)
+		assert.NoError(t, err, "Deferred stop should not fail")
+	}()
+
+	// 2. List
+	listRequest := newMockCallToolRequest("sandbox_list", nil)
+	listResult, err := ListSandboxes(ctx, listRequest)
+	require.NoError(t, err)
+	require.Len(t, listResult.Content, 1)
+
+	listTextContent, ok := listResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	
+	var sandboxes []SandboxInfo
+	err = json.Unmarshal([]byte(listTextContent.Text), &sandboxes)
+	require.NoError(t, err)
+
+	found := false
+	for _, s := range sandboxes {
+		if s.Name == containerName {
+			found = true
+			assert.Equal(t, containerID[:12], s.ContainerID)
+			assert.True(t, strings.HasPrefix(s.Image, "alpine:latest"), "Image should be alpine:latest")
+			break
+		}
+	}
+	assert.True(t, found, "Newly created container should be in the list")
+
+
+	// 3. Exec
+	execRequest := newMockCallToolRequest("sandbox_exec", map[string]interface{}{
+		"container_id_or_name": containerName,
+		"commands":             []string{"echo", "hello world"},
+	})
+	execResult, err := Exec(ctx, execRequest)
+	require.NoError(t, err)
+	require.Len(t, execResult.Content, 1)
+
+	execTextContent, ok := execResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, execTextContent.Text, "hello world")
+}


### PR DESCRIPTION
This PR introduces container naming and listing functionality as originally planned in the `feature/add-naming-functionality` branch.

Key Features:
- `sandbox_initialize` now accepts an optional `name` parameter.
- All tools that operate on containers now accept `container_id_or_name`.
- A new `sandbox_list` tool has been added to list running sandboxes.

Fixes and Improvements:
- **Build Fix:** Corrected the implementation of `tools/list.go` to be compatible with `mcp-go v0.15.0` and the latest `docker/docker` client library APIs. This resolves the build errors encountered with the original branch.
- **Integration Test:** Added `tools/tools_test.go` to provide an integration test for the full container lifecycle (initialize, list, exec, stop).

**Important Note on Testing:**
The new integration test (`TestSandboxLifecycle`) requires a running Docker daemon to execute. Due to the limitations of the current sandbox environment (where the Docker daemon is not available), this test could not be successfully run post-commit. However, the code has been written to pass in an environment with Docker. It is recommended to run this test in a suitable environment to fully validate the changes.

This PR supersedes the previous state of the branch and includes the necessary fixes to make it buildable and more robust.
