### PR TITLE
Fix: Correct schema for sandbox_list tool

### DIFF
--- a/src/code-sandbox-mcp/main.go
+++ b/src/code-sandbox-mcp/main.go
@@ -70,6 +70,7 @@ func main() {
 	listTool := mcp.NewTool("sandbox_list",
 		mcp.WithDescription("Lists all running sandbox containers, returning their ID, name, image, and status."),
 	)
+	listTool.InputSchema.Properties = make(map[string]*mcp.Schema)
 
 	// Copy a directory to the sandboxed filesystem
 	copyProjectTool := mcp.NewTool("copy_project",


### PR DESCRIPTION
This PR fixes an issue where the `sandbox_list` tool would generate a JSON schema without a `properties` field for its `inputSchema`. This could cause problems for clients that perform strict schema validation.

The fix involves explicitly initializing the `Properties` map for the tool's input schema. This ensures that a compliant schema with an empty `properties` object is always generated, correctly representing that the tool takes no arguments.